### PR TITLE
sort entries

### DIFF
--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -64,6 +64,7 @@ void SetupGenerator::generate()
         QList<const AbstractMetaClass*> list = pack.value();
         if (list.isEmpty())
             continue;
+        std::sort(list.begin(), list.end());
 
         QString packName = pack.key();
         QStringList components = packName.split(".");


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
varying ordering of functions in the output
would cause differing binaries.

See https://reproducible-builds.org/ for why this matters.